### PR TITLE
Remove eslint-config-zendesk from public code

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "babel-eslint": "^6.0.4",
     "eslint": "^2.11.1",
     "eslint-config-standard": "^5.3.1",
-    "eslint-config-zendesk": "git+ssh://git@github.com/zendeskgarden/eslint-config.git",
     "eslint-plugin-sort-class-members": "^1.0.1",
     "eslint-plugin-standard": "^1.3.2",
     "sinon": "^1.17.4"


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean @dpawluk 
### Description

Removing reference to private repo 'zendeskgarden'.  This repo is public, so it should not refer to private repos
### References
- JIRA: n/a
### Risks
- Low: could break build/linting
