### PR TITLE
CT-2676: Channelback with attachments should be documented

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const express = require('express');
 const app = express();
 const bodyParser = require('body-parser');
 
-app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
 
@@ -102,6 +102,17 @@ function channelbackMessage(req) {
 }
 
 /**
+ * Extracts any attachment URLs from a channelback POST request.  These URLs
+ * can be used to download the attachments from Zendesk using an authentication
+ * token.
+ * @param {req} req POST request
+ * @returns {array}
+ */
+function channelbackAttachmentUrls(req) {
+  return req.body.file_urls
+}
+
+/**
  * Extracts the external_id from a clickthrough GET request.  This is the
  * ID of the item they're clicking through on.
  *
@@ -134,7 +145,7 @@ app.post('/pull', (req, res) => {
 app.post('/channelback', (req, res) => {
   wordpress.channelback(
     metadata(req), parentId(req),
-    channelbackMessage(req), res);
+    channelbackMessage(req), channelbackAttachmentUrls(req), res);
 });
 
 app.get('/clickthrough', (req, res) => {

--- a/wordpress.js
+++ b/wordpress.js
@@ -109,6 +109,7 @@ exports.manifest = res => {
     id: 'com.zendesk.anychannel.integrations.wordpress',
     author: 'Zendesk',
     version: 'v0.0.1',
+    channelback_files: true,
     urls: {
       admin_ui: './admin_ui',
       pull_url: './pull',
@@ -483,7 +484,20 @@ function channelbackOptions(metadata, parent, post, content) {
  *  creating
  * @param {Object} res Response object to which JSON results will be written
  */
-exports.channelback = (metadata, parentId, channelbackMessage, res) => {
+exports.channelback = (metadata, parentId, channelbackMessage, channelbackAttachmentUrls, res) => {
+  // Wordpress doesn't support adding attachments to comments out-of-the-box, so
+  // we'll append the URLs to the comment.  This is NOT A GOOD IDEA in general
+  // since the URLs may be secured or may not be available in the future.
+  // Normally, we'd download the attachment (using the push OAuth token), then
+  // upload it to the origin service.
+  if (channelbackAttachmentUrls != null) {
+    var arrayLength = channelbackAttachmentUrls.length;
+    channelbackMessage += '\n\nAttachments:'
+    for (var i = 0; i < arrayLength; i++) {
+      channelbackMessage += '\n' + channelbackAttachmentUrls[i];
+    }
+  }
+
   const postId = parseExternalCommentId(parentId).post_id;
   const options = channelbackOptions(
     metadata,


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean @chucknado 

⚠️ Do not merge/deploy until the actual feature is merged and deployed.  See https://zendesk.atlassian.net/browse/CT-2663

### Description

Channelback now supports an optional `file_urls` argument, which indicates the attachments for a Channelback (for integrations that support that.)

Update sample integration to support Channelbacks with attachments

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-2676
* PR for the "lchan" fork: https://github.com/lchan-zendesk/sample_wordpress_anychannel_integration/pull/2

### Risks
* Low: sample code might not work right
